### PR TITLE
fix(git-add): prevent git-add from failing due to open lockfile

### DIFF
--- a/tasks/endpoints/git.js
+++ b/tasks/endpoints/git.js
@@ -81,7 +81,12 @@ module.exports = function(grunt) {
           args: args,
           opts: { stdio: streams }
         }, done)
-      }, done)
+      }, function(err, result, code) {
+        // Hopefully enough time...
+        setTimeout(function() {
+          done(err, result, code);
+        }, 500);
+      });
     },
 
     /* Commit the current changes to a changeset, with the specified message. */


### PR DESCRIPTION
With the release of TWBS v3.0.3 the other day, I found out that there are some issues with the git-add strategy in this code... It would benefit from a bit of extra safety...

I still don't want to join too many files into the same git command, so that windows doesn't have any trouble running the script...

The best I can figure is a $timeout, at least without watching the filesystem for a lockfile (which may not be present depending on git version).

This is kind of silly, and there's probably a better way around it, but a timeout it shall be.
