### PR TITLE
chore(travis): fail Travis-CI runs if tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_script:
   - npm install coveralls
 
 script:
-  - scripts/coverage.sh
-  - scripts/coveralls.sh
+  - scripts/travis.sh
+

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -5,10 +5,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$(dirname $SCRIPT_DIR)"
 cd "$ROOT_DIR"
 
-# TODO: don't include running `grunt` in the coverage... This test suite shouldn't
-# call the grunt stuff!
-istanbul cover grunt -- test
+$SCRIPT_DIR/coverage.sh
 STATUS=$?
+$SCRIPT_DIR/coveralls.sh
+
 cd "$ORIG_PWD"
 
 exit $STATUS


### PR DESCRIPTION
Travis was previously ignoring the tstatus of test runs because of the coveralls script which was
added. No regressions were merged as far as I'm aware, but this is definitely not ideal.
